### PR TITLE
Adds an exception status code for the ParentResourceNotSpecifiedException

### DIFF
--- a/src/Exceptions/ParentResourceNotSpecifiedException.php
+++ b/src/Exceptions/ParentResourceNotSpecifiedException.php
@@ -11,7 +11,7 @@ class ParentResourceNotSpecifiedException extends \Exception
      */
     public function __construct()
     {
-        parent::__construct('Parent resource not specified');
+        parent::__construct('Parent resource not specified', 422);
 
     }
 }


### PR DESCRIPTION
Adds an exception status code for the ParentResourceNotSpecifiedException to be used as the HTTP status code.